### PR TITLE
Bug: datetime from Rechtspraak API not saved as UTC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: test
+.PHONY: build destroy down logs reset schema up test
 
 COMPOSE = docker-compose -f docker-compose.yml -f docker-compose-dev.yml
 FLASK = $(COMPOSE) run --rm app flask
 WEBPACK = $(COMPOSE) run --rm webpack
 
-build: env
+build: .env
 	$(COMPOSE) pull
 	$(COMPOSE) build
 	$(WEBPACK) npm install
@@ -35,7 +35,7 @@ test:
 cli:
 	$(COMPOSE) run --rm app bash
 
-env:
+.env:
 	cp .env.dist .env
 
 import_people:

--- a/app/util.py
+++ b/app/util.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from typing import Union
 
 import pytz
-from flask import current_app
 
 
 def get_env_variable(name, default=None) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ pytest==7.1.2
 pytest-factoryboy==2.1.0
 python-dateutil==2.8.2
 python-editor==1.0.4
+pytz==2022.1
 PyYAML==6.0
 requests==2.27.1
 six==1.16.0


### PR DESCRIPTION
@siccovansas this bug was a bit more tricky than expected. The datetimes are not saved in UTC format in the database, requiring us to rescrape the professional details and the side jobs of judges.

After the deploy, you should follow these steps:

1. Stop the cron that rescrapes information.
2. Clear out the professional_detail and side_job tables.
```SQL
DELETE FROM professional_detail;
DELETE FROM side_job;
```
3. On the cli, run: `$ flask enrich_people` to rescrape.
4. Once that's done, re-enable the cron.