### PR TITLE
Extend tests and fixes scraping for institutions, legal areas and procedure types

### DIFF
--- a/app/scraper/other/config.py
+++ b/app/scraper/other/config.py
@@ -1,0 +1,3 @@
+INSTITUTIONS_URL = "https://data.rechtspraak.nl/Waardelijst/Instanties"
+LEGAL_AREAS_URL = "https://data.rechtspraak.nl/Waardelijst/Rechtsgebieden"
+PROCEDURE_TYPES_URL = "https://data.rechtspraak.nl/Waardelijst/Proceduresoorten"

--- a/app/scraper/other/institutions.py
+++ b/app/scraper/other/institutions.py
@@ -2,17 +2,18 @@ import requests
 from flask import current_app
 
 from app.models import Institution
+from app.scraper.other.config import INSTITUTIONS_URL
 from app.scraper.verdicts.soup_parsing import safe_find_text, to_soup
 
 
 def transform_institution_xml_to_dict(soup):
     return {
-        "lido_id": safe_find_text(soup, "identifier"),
-        "name": safe_find_text(soup, "naam"),
-        "abbrevation": safe_find_text(soup, "afkorting") or None,
-        "type": safe_find_text(soup, "type"),
-        "begin_date": safe_find_text(soup, "begindate") or None,
-        "end_date": safe_find_text(soup, "enddate") or None,
+        "lido_id": safe_find_text(soup, "Identifier"),
+        "name": safe_find_text(soup, "Naam"),
+        "abbrevation": safe_find_text(soup, "Afkorting") or None,
+        "type": safe_find_text(soup, "Type"),
+        "begin_date": safe_find_text(soup, "BeginDate") or None,
+        "end_date": safe_find_text(soup, "EndDate") or None,
     }
 
 
@@ -25,12 +26,10 @@ def institution_exists(institution_dict):
 
 
 def import_institutions_handler():
-    BASE_URL = "http://data.rechtspraak.nl/Waardelijst/Instanties"
-
-    r = requests.get(BASE_URL)
+    r = requests.get(INSTITUTIONS_URL)
     r.raise_for_status()
 
-    institutions = to_soup(r.content).find_all("instantie")
+    institutions = to_soup(r.content).find_all("Instantie")
     current_app.logger.info(f"Found {len(institutions)} institutions")
 
     for institution in institutions:

--- a/app/scraper/other/legal_areas.py
+++ b/app/scraper/other/legal_areas.py
@@ -2,13 +2,14 @@ import requests
 from flask import current_app
 
 from app.models import LegalArea
+from app.scraper.other.config import LEGAL_AREAS_URL
 from app.scraper.verdicts.soup_parsing import safe_find_text, to_soup
 
 
 def transform_legal_area_xml_to_dict(area):
     return {
-        "legal_area_lido_id": safe_find_text(area, "identifier"),
-        "legal_area_name": safe_find_text(area, "naam"),
+        "legal_area_lido_id": safe_find_text(area, "Identifier"),
+        "legal_area_name": safe_find_text(area, "Naam"),
     }
 
 
@@ -21,15 +22,13 @@ def legal_area_exists(legal_area_dict):
 
 
 def import_legal_areas_handler():
-    BASE_URL = "http://data.rechtspraak.nl/Waardelijst/Rechtsgebieden"
-
-    r = requests.get(BASE_URL)
+    r = requests.get(LEGAL_AREAS_URL)
     r.raise_for_status()
 
     main_areas = (
         to_soup(r.content)
-        .find("rechtsgebieden")
-        .findChildren("rechtsgebied", recursive=False)
+        .find("Rechtsgebieden")
+        .findChildren("Rechtsgebied", recursive=False)
     )
     current_app.logger.info(f"Found {len(main_areas)} main legal areas")
 
@@ -38,7 +37,7 @@ def import_legal_areas_handler():
         if not legal_area_exists(legal_area_dict):
             LegalArea.create(**legal_area_dict)
 
-        sub_areas = main_area.find_all("rechtsgebied")
+        sub_areas = main_area.find_all("Rechtsgebied")
         current_app.logger.info(f"Found {len(sub_areas)} sub areas")
 
         for sub_area in sub_areas:

--- a/app/scraper/other/procedure_types.py
+++ b/app/scraper/other/procedure_types.py
@@ -2,13 +2,14 @@ import requests
 from flask import current_app
 
 from app.models import ProcedureType
+from app.scraper.other.config import PROCEDURE_TYPES_URL
 from app.scraper.verdicts.soup_parsing import safe_find_text, to_soup
 
 
 def transform_procedure_type_xml_to_dict(soup):
     return {
-        "lido_id": safe_find_text(soup, "identifier"),
-        "name": safe_find_text(soup, "naam"),
+        "lido_id": safe_find_text(soup, "Identifier"),
+        "name": safe_find_text(soup, "Naam"),
     }
 
 
@@ -21,12 +22,10 @@ def procedure_type_exists(procedure_type_dict):
 
 
 def import_procedure_types_handler():
-    BASE_URL = "http://data.rechtspraak.nl/Waardelijst/Proceduresoorten"
-
-    r = requests.get(BASE_URL)
+    r = requests.get(PROCEDURE_TYPES_URL)
     r.raise_for_status()
 
-    procedure_types = to_soup(r.content).find_all("proceduresoort")
+    procedure_types = to_soup(r.content).find_all("Proceduresoort")
     current_app.logger.info(f"Found {len(procedure_types)} procedure types")
 
     for procedure_type in procedure_types:

--- a/app/scraper/other/tests/fixtures.py
+++ b/app/scraper/other/tests/fixtures.py
@@ -1,0 +1,141 @@
+NO_INSTITUTIONS_XML = """
+<Instanties>
+</Instanties>"""
+
+ONE_INSTITUTION_XML = """
+<Instanties>
+    <Instantie>
+        <Identifier>http://psi.rechtspraak.nl/agam</Identifier>
+        <Naam>Ambtenarengerecht Amsterdam</Naam>
+        <Afkorting>AGAMS</Afkorting>
+        <Type>AndereGerechtelijkeInstantie</Type>
+        <BeginDate>1913-01-01</BeginDate>
+    </Instantie>
+</Instanties>
+"""
+
+FIVE_INSTITUTIONS_XML = """
+<Instanties>
+    <Instantie>
+        <Identifier>http://psi.rechtspraak.nl/agam</Identifier>
+        <Naam>Ambtenarengerecht Amsterdam</Naam>
+        <Afkorting>AGAMS</Afkorting>
+        <Type>AndereGerechtelijkeInstantie</Type>
+        <BeginDate>1913-01-01</BeginDate>
+    </Instantie>
+    <Instantie>
+        <Identifier>http://psi.rechtspraak.nl/agah</Identifier>
+        <Naam>Ambtenarengerecht Arnhem</Naam>
+        <Afkorting>AGARN</Afkorting>
+        <Type>AndereGerechtelijkeInstantie</Type>
+        <BeginDate>1913-01-01</BeginDate>
+    </Instantie>
+    <Instantie>
+        <Identifier>http://psi.rechtspraak.nl/aggr</Identifier>
+        <Naam>Ambtenarengerecht Groningen</Naam>
+        <Afkorting>AGGRO</Afkorting>
+        <Type>AndereGerechtelijkeInstantie</Type>
+        <BeginDate>1950-01-01</BeginDate>
+    </Instantie>
+    <Instantie>
+        <Identifier>http://psi.rechtspraak.nl/aghl</Identifier>
+        <Naam>Ambtenarengerecht Haarlem</Naam>
+        <Afkorting>AGHAA</Afkorting>
+        <Type>AndereGerechtelijkeInstantie</Type>
+        <BeginDate>1950-01-01</BeginDate>
+    </Instantie>
+    <Instantie>
+        <Identifier>http://psi.rechtspraak.nl/agrm</Identifier>
+        <Naam>Ambtenarengerecht Roermond</Naam>
+        <Afkorting>AGROE</Afkorting>
+        <Type>AndereGerechtelijkeInstantie</Type>
+        <BeginDate>1950-01-01</BeginDate>
+    </Instantie>
+</Instanties>
+"""
+
+NO_LEGAL_AREAS_XML = """
+<Rechtsgebieden>
+</Rechtsgebieden>"""
+
+ONE_MAIN_AND_ONE_SUB_LEGAL_AREA_XML = """
+<Rechtsgebieden>
+    <Rechtsgebied>
+        <Identifier>http://psi.rechtspraak.nl/rechtsgebied#bestuursrecht</Identifier>
+        <Naam>Bestuursrecht</Naam>
+        <Rechtsgebied>
+            <Identifier>http://psi.rechtspraak.nl/rechtsgebied#bestuursrecht_ambtenarenrecht</Identifier>
+            <Naam>Ambtenarenrecht</Naam>
+        </Rechtsgebied>
+    </Rechtsgebied>
+</Rechtsgebieden>"""
+
+TWO_MAIN_AND_TWO_SUB_LEGAL_AREAS_XML = """
+<Rechtsgebieden>
+    <Rechtsgebied>
+        <Identifier>
+        http://psi.rechtspraak.nl/rechtsgebied#bestuursrecht
+        </Identifier>
+        <Rechtsgebied>
+            <Identifier>http://psi.rechtspraak.nl/rechtsgebied#bestuursrecht_ambtenarenrecht</Identifier>
+            <Naam>Ambtenarenrecht</Naam>
+        </Rechtsgebied>
+        <Rechtsgebied>
+            <Identifier>http://psi.rechtspraak.nl/rechtsgebied#bestuursrecht_belastingrecht</Identifier>
+            <Naam>Belastingrecht</Naam>
+        </Rechtsgebied>
+    </Rechtsgebied>
+    <Rechtsgebied>
+        <Identifier>http://psi.rechtspraak.nl/rechtsgebied#civielRecht</Identifier>
+        <Naam>Civiel recht</Naam>
+        <Rechtsgebied>
+            <Identifier>http://psi.rechtspraak.nl/rechtsgebied#civielRecht_aanbestedingsrecht</Identifier>
+            <Naam>Aanbestedingsrecht</Naam>
+        </Rechtsgebied>
+        <Rechtsgebied>
+            <Identifier>http://psi.rechtspraak.nl/rechtsgebied#civielRecht_arbeidsrecht</Identifier>
+            <Naam>Arbeidsrecht</Naam>
+        </Rechtsgebied>
+    </Rechtsgebied>
+</Rechtsgebieden>"""
+
+
+NO_PROCEDURE_TYPES_XML = """
+<Proceduresoorten>
+</Proceduresoorten>"""
+
+ONE_PROCEDURE_TYPE_XML = """
+<Proceduresoorten>
+    <Proceduresoort>
+        <Identifier>http://psi.rechtspraak.nl/procedure#artikel81ROzaken</Identifier>
+        <Naam>Artikel 81 RO-zaken</Naam>
+    </Proceduresoort>
+</Proceduresoorten>
+"""
+
+FIVE_PROCEDURE_TYPES_XML = """
+<Proceduresoorten>
+    <Proceduresoort>
+        <Identifier>http://psi.rechtspraak.nl/procedure#artikel81ROzaken</Identifier>
+        <Naam>Artikel 81 RO-zaken</Naam>
+    </Proceduresoort>
+    <Proceduresoort>
+        <Identifier>http://psi.rechtspraak.nl/procedure#bodemzaak</Identifier>
+        <Naam>Bodemzaak</Naam>
+    </Proceduresoort>
+    <Proceduresoort>
+        <Identifier>http://psi.rechtspraak.nl/procedure#cassatie</Identifier>
+        <Naam>Cassatie</Naam>
+    </Proceduresoort>
+    <Proceduresoort>
+        <Identifier>
+        http://psi.rechtspraak.nl/procedure#cassatieInHetBelangDerWet
+        </Identifier>
+    <Naam>Cassatie in het belang der wet</Naam>
+    </Proceduresoort>
+    <Proceduresoort>
+        <Identifier>http://psi.rechtspraak.nl/procedure#conservatoireMaatregel</Identifier>
+        <Naam>Conservatoire maatregel</Naam>
+    </Proceduresoort>
+</Proceduresoorten>
+"""

--- a/app/scraper/other/tests/test_institutions.py
+++ b/app/scraper/other/tests/test_institutions.py
@@ -1,0 +1,53 @@
+from app.models import Institution
+from app.scraper.other.config import INSTITUTIONS_URL
+from app.scraper.other.institutions import import_institutions_handler
+from app.scraper.other.tests.fixtures import (
+    FIVE_INSTITUTIONS_XML,
+    NO_INSTITUTIONS_XML,
+    ONE_INSTITUTION_XML,
+)
+
+
+def test_request_creates_institution(requests_mock):
+    requests_mock.get(INSTITUTIONS_URL, status_code=200, text=ONE_INSTITUTION_XML)
+
+    assert Institution.query.count() == 0
+    import_institutions_handler()
+    assert Institution.query.count() == 1
+
+
+def test_institution_attributes_are_mapped_correctly(requests_mock):
+    requests_mock.get(INSTITUTIONS_URL, status_code=200, text=ONE_INSTITUTION_XML)
+
+    import_institutions_handler()
+    institution = Institution.query.first()
+
+    assert institution.name == "Ambtenarengerecht Amsterdam"
+    assert institution.abbrevation == "AGAMS"
+    assert institution.lido_id == "http://psi.rechtspraak.nl/agam"
+
+
+def test_request_creates_multiple_institutions(requests_mock):
+    requests_mock.get(INSTITUTIONS_URL, status_code=200, text=FIVE_INSTITUTIONS_XML)
+
+    assert Institution.query.count() == 0
+    import_institutions_handler()
+    assert Institution.query.count() == 5
+
+
+def test_only_one_institution_is_created_on_subsequent_scrapes(requests_mock):
+    requests_mock.get(INSTITUTIONS_URL, status_code=200, text=ONE_INSTITUTION_XML)
+
+    assert Institution.query.count() == 0
+    import_institutions_handler()
+    assert Institution.query.count() == 1
+    import_institutions_handler()
+    assert Institution.query.count() == 1
+
+
+def test_no_institution_is_created(requests_mock):
+    requests_mock.get(INSTITUTIONS_URL, status_code=200, text=NO_INSTITUTIONS_XML)
+
+    assert Institution.query.count() == 0
+    import_institutions_handler()
+    assert Institution.query.count() == 0

--- a/app/scraper/other/tests/test_legal_areas.py
+++ b/app/scraper/other/tests/test_legal_areas.py
@@ -1,0 +1,63 @@
+from app.models import LegalArea
+from app.scraper.other.config import LEGAL_AREAS_URL
+from app.scraper.other.legal_areas import import_legal_areas_handler
+from app.scraper.other.tests.fixtures import (
+    NO_LEGAL_AREAS_XML,
+    ONE_MAIN_AND_ONE_SUB_LEGAL_AREA_XML,
+    TWO_MAIN_AND_TWO_SUB_LEGAL_AREAS_XML,
+)
+
+
+def test_request_creates_legal_area(requests_mock):
+    requests_mock.get(
+        LEGAL_AREAS_URL, status_code=200, text=ONE_MAIN_AND_ONE_SUB_LEGAL_AREA_XML
+    )
+
+    assert LegalArea.query.count() == 0
+    import_legal_areas_handler()
+    assert LegalArea.query.count() == 2
+
+
+def test_legal_area_attributes_are_mapped_correctly(requests_mock):
+    requests_mock.get(
+        LEGAL_AREAS_URL, status_code=200, text=ONE_MAIN_AND_ONE_SUB_LEGAL_AREA_XML
+    )
+
+    import_legal_areas_handler()
+    legal_area = LegalArea.query.first()
+
+    assert legal_area.legal_area_name == "Bestuursrecht"
+    assert (
+        legal_area.legal_area_lido_id
+        == "http://psi.rechtspraak.nl/rechtsgebied#bestuursrecht"
+    )
+
+
+def test_request_creates_multiple_legal_areas(requests_mock):
+    requests_mock.get(
+        LEGAL_AREAS_URL, status_code=200, text=TWO_MAIN_AND_TWO_SUB_LEGAL_AREAS_XML
+    )
+
+    assert LegalArea.query.count() == 0
+    import_legal_areas_handler()
+    assert LegalArea.query.count() == 6
+
+
+def test_only_one_legal_area_is_created_on_subsequent_scrapes(requests_mock):
+    requests_mock.get(
+        LEGAL_AREAS_URL, status_code=200, text=ONE_MAIN_AND_ONE_SUB_LEGAL_AREA_XML
+    )
+
+    assert LegalArea.query.count() == 0
+    import_legal_areas_handler()
+    assert LegalArea.query.count() == 2
+    import_legal_areas_handler()
+    assert LegalArea.query.count() == 2
+
+
+def test_no_legal_area_is_created(requests_mock):
+    requests_mock.get(LEGAL_AREAS_URL, status_code=200, text=NO_LEGAL_AREAS_XML)
+
+    assert LegalArea.query.count() == 0
+    import_legal_areas_handler()
+    assert LegalArea.query.count() == 0

--- a/app/scraper/other/tests/test_procedure_types.py
+++ b/app/scraper/other/tests/test_procedure_types.py
@@ -1,0 +1,56 @@
+from app.models import ProcedureType
+from app.scraper.other.config import PROCEDURE_TYPES_URL
+from app.scraper.other.procedure_types import import_procedure_types_handler
+from app.scraper.other.tests.fixtures import (
+    FIVE_PROCEDURE_TYPES_XML,
+    NO_PROCEDURE_TYPES_XML,
+    ONE_PROCEDURE_TYPE_XML,
+)
+
+
+def test_request_creates_procedure_type(requests_mock):
+    requests_mock.get(PROCEDURE_TYPES_URL, status_code=200, text=ONE_PROCEDURE_TYPE_XML)
+
+    assert ProcedureType.query.count() == 0
+    import_procedure_types_handler()
+    assert ProcedureType.query.count() == 1
+
+
+def test_procedure_type_attributes_are_mapped_correctly(requests_mock):
+    requests_mock.get(PROCEDURE_TYPES_URL, status_code=200, text=ONE_PROCEDURE_TYPE_XML)
+
+    import_procedure_types_handler()
+    procedure_type = ProcedureType.query.first()
+
+    assert procedure_type.name == "Artikel 81 RO-zaken"
+    assert (
+        procedure_type.lido_id == "http://psi.rechtspraak.nl/procedure#artikel81ROzaken"
+    )
+
+
+def test_request_creates_multiple_procedure_types(requests_mock):
+    requests_mock.get(
+        PROCEDURE_TYPES_URL, status_code=200, text=FIVE_PROCEDURE_TYPES_XML
+    )
+
+    assert ProcedureType.query.count() == 0
+    import_procedure_types_handler()
+    assert ProcedureType.query.count() == 5
+
+
+def test_only_one_procedure_type_is_created_on_subsequent_scrapes(requests_mock):
+    requests_mock.get(PROCEDURE_TYPES_URL, status_code=200, text=ONE_PROCEDURE_TYPE_XML)
+
+    assert ProcedureType.query.count() == 0
+    import_procedure_types_handler()
+    assert ProcedureType.query.count() == 1
+    import_procedure_types_handler()
+    assert ProcedureType.query.count() == 1
+
+
+def test_no_procedure_type_is_created(requests_mock):
+    requests_mock.get(PROCEDURE_TYPES_URL, status_code=200, text=NO_PROCEDURE_TYPES_XML)
+
+    assert ProcedureType.query.count() == 0
+    import_procedure_types_handler()
+    assert ProcedureType.query.count() == 0

--- a/app/scraper/verdicts/soup_parsing.py
+++ b/app/scraper/verdicts/soup_parsing.py
@@ -63,10 +63,10 @@ def find_institution_identifier(soup):
 def find_procedure_type_identifier(soup):
     procedure_type = soup.find("psi:procedure")
     if procedure_type:
-        return procedure_type["resourceidentifier"]
+        return procedure_type.get("resourceIdentifier")
 
 
 def find_legal_area_identifier(soup):
     legal_area = soup.find("dcterms:subject")
     if legal_area:
-        return legal_area["resourceidentifier"]
+        return legal_area.get("resourceIdentifier")


### PR DESCRIPTION
Extends tests for scraping institutions, legal areas and procedure types. Additionally, also closes Sentry issues 4, 5 and 6.