### PR TITLE
Optimize n+1 query

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Union
 
-from app.models import Person, ProfessionalDetail, Verdict
+from app.models import Person, Verdict
 
 
 def serialize_dt(dt: datetime) -> Union[str, None]:
@@ -9,9 +9,10 @@ def serialize_dt(dt: datetime) -> Union[str, None]:
 
 
 def person_list_serializer(person: Person):
-    professional_details = ProfessionalDetail.query.filter(
-        ProfessionalDetail.person_id == person.id
-    ).filter(ProfessionalDetail.end_date.is_(None))
+    # only show professional details that are still active
+    professional_details = [
+        detail for detail in person.professional_detail if detail.end_date is not None
+    ]
     return {
         "id": person.id,
         "titles": person.titles,

--- a/app/api/services.py
+++ b/app/api/services.py
@@ -47,7 +47,9 @@ class PersonService(BaseService):
     def __init__(self, query_params=MultiDict[str, str]):
         super().__init__(query_params)
         self.query_params = query_params
-        self.queryset = Person.query.filter(Person.protected.isnot(True))
+        self.queryset = Person.query.filter(Person.protected.isnot(True)).options(
+            joinedload(Person.professional_detail)
+        )
         self.order = [Person.last_name.asc(), Person.id.asc()]
 
     def apply_filtering(self):
@@ -58,7 +60,6 @@ class PersonService(BaseService):
         include_former_judges = self.query_params.get(
             "former_judges", default=False, type=lambda v: v.lower() == "true"
         )
-        print(include_former_judges, type(include_former_judges), flush=True)
         if include_former_judges is False:
             self.queryset = self.queryset.filter(
                 Person.removed_from_rechtspraak_at.is_(None)


### PR DESCRIPTION
This fixes the n+1 query notification we've been getting from Sentry (issue 4475390153). Prevents ~50 queries on loading the index page :)