### PR TITLE
Add rate limiting to fix issue 77

### DIFF
--- a/app/scraper/other/institutions.py
+++ b/app/scraper/other/institutions.py
@@ -1,8 +1,8 @@
-import requests
 from flask import current_app
 
 from app.models import Institution
 from app.scraper.other.config import INSTITUTIONS_URL
+from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 from app.scraper.soup_parsing import safe_find_text, to_soup
 
 
@@ -26,17 +26,18 @@ def institution_exists(institution_dict):
 
 
 def import_institutions_handler():
-    r = requests.get(INSTITUTIONS_URL)
-    r.raise_for_status()
+    with RechtspraakScrapeSession() as session:
+        r = session.get(INSTITUTIONS_URL)
+        r.raise_for_status()
 
-    institutions = to_soup(r.content).find_all("Instantie")
-    current_app.logger.info(f"Found {len(institutions)} institutions")
+        institutions = to_soup(r.content).find_all("Instantie")
+        current_app.logger.info(f"Found {len(institutions)} institutions")
 
-    for institution in institutions:
-        institution_dict = transform_institution_xml_to_dict(institution)
+        for institution in institutions:
+            institution_dict = transform_institution_xml_to_dict(institution)
 
-        if not institution_exists(institution_dict):
-            Institution.create(**institution_dict)
-            current_app.logger.info(
-                f"New institution {institution_dict.get('name')} added"
-            )
+            if not institution_exists(institution_dict):
+                Institution.create(**institution_dict)
+                current_app.logger.info(
+                    f"New institution {institution_dict.get('name')} added"
+                )

--- a/app/scraper/other/legal_areas.py
+++ b/app/scraper/other/legal_areas.py
@@ -1,8 +1,8 @@
-import requests
 from flask import current_app
 
 from app.models import LegalArea
 from app.scraper.other.config import LEGAL_AREAS_URL
+from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 from app.scraper.soup_parsing import safe_find_text, to_soup
 
 
@@ -22,29 +22,30 @@ def legal_area_exists(legal_area_dict):
 
 
 def import_legal_areas_handler():
-    r = requests.get(LEGAL_AREAS_URL)
-    r.raise_for_status()
+    with RechtspraakScrapeSession() as session:
+        r = session.get(LEGAL_AREAS_URL)
+        r.raise_for_status()
 
-    main_areas = (
-        to_soup(r.content)
-        .find("Rechtsgebieden")
-        .findChildren("Rechtsgebied", recursive=False)
-    )
-    current_app.logger.info(f"Found {len(main_areas)} main legal areas")
+        main_areas = (
+            to_soup(r.content)
+            .find("Rechtsgebieden")
+            .findChildren("Rechtsgebied", recursive=False)
+        )
+        current_app.logger.info(f"Found {len(main_areas)} main legal areas")
 
-    for main_area in main_areas:
-        legal_area_dict = transform_legal_area_xml_to_dict(main_area)
-        if not legal_area_exists(legal_area_dict):
-            LegalArea.create(**legal_area_dict)
-
-        sub_areas = main_area.find_all("Rechtsgebied")
-        current_app.logger.info(f"Found {len(sub_areas)} sub areas")
-
-        for sub_area in sub_areas:
-            legal_area_dict = transform_legal_area_xml_to_dict(sub_area)
-
+        for main_area in main_areas:
+            legal_area_dict = transform_legal_area_xml_to_dict(main_area)
             if not legal_area_exists(legal_area_dict):
                 LegalArea.create(**legal_area_dict)
-                current_app.logger.info(
-                    f"New legal area {legal_area_dict.get('legal_area_name')} added"
-                )
+
+            sub_areas = main_area.find_all("Rechtsgebied")
+            current_app.logger.info(f"Found {len(sub_areas)} sub areas")
+
+            for sub_area in sub_areas:
+                legal_area_dict = transform_legal_area_xml_to_dict(sub_area)
+
+                if not legal_area_exists(legal_area_dict):
+                    LegalArea.create(**legal_area_dict)
+                    current_app.logger.info(
+                        f"New legal area {legal_area_dict.get('legal_area_name')} added"
+                    )

--- a/app/scraper/other/procedure_types.py
+++ b/app/scraper/other/procedure_types.py
@@ -1,8 +1,8 @@
-import requests
 from flask import current_app
 
 from app.models import ProcedureType
 from app.scraper.other.config import PROCEDURE_TYPES_URL
+from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 from app.scraper.soup_parsing import safe_find_text, to_soup
 
 
@@ -22,17 +22,18 @@ def procedure_type_exists(procedure_type_dict):
 
 
 def import_procedure_types_handler():
-    r = requests.get(PROCEDURE_TYPES_URL)
-    r.raise_for_status()
+    with RechtspraakScrapeSession() as session:
+        r = session.get(PROCEDURE_TYPES_URL)
+        r.raise_for_status()
 
-    procedure_types = to_soup(r.content).find_all("Proceduresoort")
-    current_app.logger.info(f"Found {len(procedure_types)} procedure types")
+        procedure_types = to_soup(r.content).find_all("Proceduresoort")
+        current_app.logger.info(f"Found {len(procedure_types)} procedure types")
 
-    for procedure_type in procedure_types:
-        procedure_type_dict = transform_procedure_type_xml_to_dict(procedure_type)
+        for procedure_type in procedure_types:
+            procedure_type_dict = transform_procedure_type_xml_to_dict(procedure_type)
 
-        if not procedure_type_exists(procedure_type_dict):
-            ProcedureType.create(**procedure_type_dict)
-            current_app.logger.info(
-                f"New procedure type {procedure_type_dict.get('name')} added"
-            )
+            if not procedure_type_exists(procedure_type_dict):
+                ProcedureType.create(**procedure_type_dict)
+                current_app.logger.info(
+                    f"New procedure type {procedure_type_dict.get('name')} added"
+                )

--- a/app/scraper/people/enrich_people.py
+++ b/app/scraper/people/enrich_people.py
@@ -15,73 +15,74 @@ from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 def enrich_people_handler():
     people = Person.query.all()
 
-    for person in people:
-        enrich_person(person)
+    # Rate limit to default requests p/s, which means that enriching 5.000 judges will take a little less than 3 hours
+    with RechtspraakScrapeSession() as session:
+        for person in people:
+            enrich_person(session, person)
 
 
 def person_details_url(rechtspraak_id: str) -> str:
     return DETAILS_ENDPOINT + rechtspraak_id
 
 
-def enrich_person(person: Person) -> None:
-    with RechtspraakScrapeSession() as session:
-        r = session.get(person_details_url(person.rechtspraak_id))
-        current_app.logger.info(
-            f"Enriching person {person.id} with information from {r.url}"
+def enrich_person(session: RechtspraakScrapeSession, person: Person) -> None:
+    r = session.get(person_details_url(person.rechtspraak_id))
+    current_app.logger.info(
+        f"Enriching person {person.id} with information from {r.url}"
+    )
+
+    if not r.ok or r.url == FAULTY_URL:
+        current_app.logger.warning(
+            f"Enrichtment of person {person.id} failed with status {r.status_code}, url {r.url}",
+            extra={"id": person.id},
         )
-
-        if not r.ok or r.url == FAULTY_URL:
-            current_app.logger.warning(
-                f"Enrichtment of person {person.id} failed with status {r.status_code}, url {r.url}",
-                extra={"id": person.id},
-            )
-            person.removed_from_rechtspraak_at = datetime.now()
-            person.last_scraped_at = datetime.now()
-            person.save()
-            return
-
-        person_json = r.json().get("model", {})
-
-        for beroepsgegeven in person_json.get("beroepsgegevens", []):
-            pd_kwargs = ProfessionalDetail.transform_beroepsgegevens_dict(
-                beroepsgegeven
-            )
-            if not professional_detail_already_exists(person, pd_kwargs):
-                institution = find_institution_for_professional_detail(
-                    pd_kwargs.get("organisation")
-                )
-                ProfessionalDetail.create(
-                    **{"person_id": person.id, **pd_kwargs}, institution=institution
-                )
-
-        for historisch_beroepsgegeven in person_json.get("historieBeroepsgegevens", []):
-            pd_kwargs = ProfessionalDetail.transform_historisch_beroepsgegevens_dict(
-                historisch_beroepsgegeven
-            )
-            if not professional_detail_already_exists(person, pd_kwargs):
-                institution = find_institution_for_professional_detail(
-                    pd_kwargs.get("organisation")
-                )
-                ProfessionalDetail.create(
-                    **{"person_id": person.id, **pd_kwargs}, institution=institution
-                )
-
-        for nevenbetrekking in person_json.get("huidigeNevenbetrekkingen", []):
-            nb_kwargs = SideJob.transform_huidige_nevenbetrekkingen_dict(
-                nevenbetrekking
-            )
-            if not side_job_already_exists(person, nb_kwargs):
-                SideJob.create(**{"person_id": person.id, **nb_kwargs})
-
-        for voorgaande_nevenbetrekking in person_json.get(
-            "voorgaandeNevenbetrekkingen", []
-        ):
-            nb_kwargs = SideJob.transform_voorgaande_nevenbetrekkingen_dict(
-                voorgaande_nevenbetrekking
-            )
-            if not side_job_already_exists(person, nb_kwargs):
-                SideJob.create(**{"person_id": person.id, **nb_kwargs})
-
-        person.removed_from_rechtspraak_at = None
+        person.removed_from_rechtspraak_at = datetime.now()
         person.last_scraped_at = datetime.now()
         person.save()
+        return
+
+    person_json = r.json().get("model", {})
+
+    for beroepsgegeven in person_json.get("beroepsgegevens", []):
+        pd_kwargs = ProfessionalDetail.transform_beroepsgegevens_dict(
+            beroepsgegeven
+        )
+        if not professional_detail_already_exists(person, pd_kwargs):
+            institution = find_institution_for_professional_detail(
+                pd_kwargs.get("organisation")
+            )
+            ProfessionalDetail.create(
+                **{"person_id": person.id, **pd_kwargs}, institution=institution
+            )
+
+    for historisch_beroepsgegeven in person_json.get("historieBeroepsgegevens", []):
+        pd_kwargs = ProfessionalDetail.transform_historisch_beroepsgegevens_dict(
+            historisch_beroepsgegeven
+        )
+        if not professional_detail_already_exists(person, pd_kwargs):
+            institution = find_institution_for_professional_detail(
+                pd_kwargs.get("organisation")
+            )
+            ProfessionalDetail.create(
+                **{"person_id": person.id, **pd_kwargs}, institution=institution
+            )
+
+    for nevenbetrekking in person_json.get("huidigeNevenbetrekkingen", []):
+        nb_kwargs = SideJob.transform_huidige_nevenbetrekkingen_dict(
+            nevenbetrekking
+        )
+        if not side_job_already_exists(person, nb_kwargs):
+            SideJob.create(**{"person_id": person.id, **nb_kwargs})
+
+    for voorgaande_nevenbetrekking in person_json.get(
+        "voorgaandeNevenbetrekkingen", []
+    ):
+        nb_kwargs = SideJob.transform_voorgaande_nevenbetrekkingen_dict(
+            voorgaande_nevenbetrekking
+        )
+        if not side_job_already_exists(person, nb_kwargs):
+            SideJob.create(**{"person_id": person.id, **nb_kwargs})
+
+    person.removed_from_rechtspraak_at = None
+    person.last_scraped_at = datetime.now()
+    person.save()

--- a/app/scraper/people/tests/test_enrich.py
+++ b/app/scraper/people/tests/test_enrich.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 from app.scraper.people.enrich_people import enrich_person, person_details_url
 from app.tests.factories import PersonFactory
 
@@ -10,7 +11,8 @@ def test_removed_at_is_not_set(requests_mock, person):
     )
 
     assert person.removed_from_rechtspraak_at is None
-    enrich_person(person)
+    with RechtspraakScrapeSession() as session:
+        enrich_person(session, person)
     assert person.removed_from_rechtspraak_at is None
 
 
@@ -18,7 +20,8 @@ def test_removed_at_is_set_on_http_error(requests_mock, person):
     requests_mock.get(person_details_url(person.rechtspraak_id), status_code=500)
 
     assert person.removed_from_rechtspraak_at is None
-    enrich_person(person)
+    with RechtspraakScrapeSession() as session:
+        enrich_person(session, person)
     assert person.removed_from_rechtspraak_at is not None
 
 
@@ -30,5 +33,6 @@ def test_removed_at_is_removed_on_successful_scrape(requests_mock):
     )
 
     assert person.removed_from_rechtspraak_at == dt
-    enrich_person(person)
+    with RechtspraakScrapeSession() as session:
+        enrich_person(session, person)
     assert person.removed_from_rechtspraak_at is None

--- a/app/scraper/rechtspraak_session.py
+++ b/app/scraper/rechtspraak_session.py
@@ -1,5 +1,7 @@
 from requests import Session
-from requests.adapters import HTTPAdapter, Retry
+from requests.adapters import Retry
+
+from requests_ratelimiter import LimiterAdapter
 
 
 class RechtspraakScrapeSession(Session):
@@ -14,14 +16,16 @@ class RechtspraakScrapeSession(Session):
 
     def __init__(self):
         super().__init__()
+
         retries = Retry(
             total=3,
             backoff_factor=2,
             raise_on_status=False,
             status_forcelist=tuple(range(401, 600)),
         )
-        self.mount("http://", HTTPAdapter(max_retries=retries))
-        self.mount("https://", HTTPAdapter(max_retries=retries))
+        adapter = LimiterAdapter(per_second=0.5, per_minute=30, burst=1, max_retries=retries)
+        self.mount("http://", adapter)
+        self.mount("https://", adapter)
 
     def request(self, *args, **kwargs):
         kwargs.setdefault("timeout", 2)

--- a/app/scraper/verdicts/enrich_verdicts.py
+++ b/app/scraper/verdicts/enrich_verdicts.py
@@ -1,12 +1,12 @@
 import math
 from datetime import datetime
 
-import requests
 from flask import current_app
 from sqlalchemy.exc import DataError
 
 from app.errors import EnrichError
 from app.models import Institution, LegalArea, PersonVerdict, ProcedureType, Verdict
+from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 from app.scraper.soup_parsing import (
     find_beslissing,
     find_institution_identifier,
@@ -27,31 +27,33 @@ def enrich_verdicts_handler():
         f"{runs} number of runs needed to enrich {total_no_of_verdicts} un-enriched verdicts"
     )
 
-    for run in range(0, runs):
-        offset = run * 1000
-        current_app.logger.info(f"Run {run} with offset {offset}")
-        verdicts = base_query.limit(1000).all()
-        for verdict in verdicts:
-            try:
-                if verdict.raw_xml is None:
-                    enrich_verdict(verdict)
+    with RechtspraakScrapeSession() as session:
+        for run in range(0, runs):
+            offset = run * 1000
+            current_app.logger.info(f"Run {run} with offset {offset}")
+            verdicts = base_query.limit(1000).all()
 
-                if verdict.raw_xml is not None:
-                    find_people_for_verdict(verdict)
-                    find_institution_for_verdict(verdict)
-                    find_procedure_type_for_verdict(verdict)
-                    find_legal_area_for_verdict(verdict)
-            except EnrichError:
-                current_app.logger.error(
-                    "An unknown problem during verdict enrichment was encountered."
-                )
-                pass
+            for verdict in verdicts:
+                try:
+                    if verdict.raw_xml is None:
+                        enrich_verdict(session, verdict)
+
+                    if verdict.raw_xml is not None:
+                        find_people_for_verdict(verdict)
+                        find_institution_for_verdict(verdict)
+                        find_procedure_type_for_verdict(verdict)
+                        find_legal_area_for_verdict(verdict)
+                except EnrichError:
+                    current_app.logger.error(
+                        "An unknown problem during verdict enrichment was encountered."
+                    )
+                    pass
 
 
-def enrich_verdict(verdict):
+def enrich_verdict(session: RechtspraakScrapeSession, verdict):
     current_app.logger.debug(f"Enriching {verdict.ecli}")
     params = {"id": verdict.ecli}
-    r = requests.get(DETAILS_ENDPOINT, params=params)
+    r = session.get(DETAILS_ENDPOINT, params=params)
     current_app.logger.info(f"Collecting verdict information from {r.url}")
 
     if not r.ok or r.url == FAULTY_URL:

--- a/app/scraper/verdicts/import_verdicts.py
+++ b/app/scraper/verdicts/import_verdicts.py
@@ -1,8 +1,8 @@
-import requests
 from flask import current_app
 
 from app.models import Verdict
 from app.scraper.soup_parsing import extract_verdicts, to_soup
+from app.scraper.rechtspraak_session import RechtspraakScrapeSession
 from app.scraper.verdicts.config import (
     DEFAULT_LIMIT,
     DEFAULT_SEARCH_QUERY_PARAMS,
@@ -18,44 +18,44 @@ def import_verdicts_handler(start_datetime: str, end_datetime: str):
 
     See https://www.rechtspraak.nl/Uitspraken/paginas/open-data.aspx for more details on how the search endpoint works.
     """
+    with RechtspraakScrapeSession() as session:
+        params = DEFAULT_SEARCH_QUERY_PARAMS
+        params["date"] = [start_datetime, end_datetime]
 
-    params = DEFAULT_SEARCH_QUERY_PARAMS
-    params["date"] = [start_datetime, end_datetime]
-
-    while True:
-        current_app.logger.info(
-            f"Collecting verdicts from {SEARCH_ENDPOINT} with params: {params}"
-        )
-        r = requests.get(SEARCH_ENDPOINT, params=params)
-
-        if not r.ok or r.url == FAULTY_URL:
-            current_app.logger.error(
-                f"Error during verdict collection: STATUS_CODE {r.status_code} | URL {r.url} | CONTENT {r.content}"
-            )
-            return
-
-        verdicts = extract_verdicts(to_soup(r.content))
-
-        current_app.logger.info(f"{len(verdicts)} verdicts found for {r.url}")
-
-        for verdict in verdicts:
-            verdict_kwargs = {
-                "ecli": verdict.id.text,
-                "title": verdict.title.text,
-                "summary": verdict.summary.text,
-                "uri": verdict.link["href"],
-            }
-            if not verdict_already_exists(verdict_kwargs.get("ecli")):
-                Verdict.create(**verdict_kwargs)
-            else:
-                current_app.logger.debug(
-                    f'Verdict for {verdict_kwargs.get("ecli")} already exists'
-                )
-
-        params["from"] = params["from"] + DEFAULT_LIMIT
-
-        if len(verdicts) < DEFAULT_LIMIT:
+        while True:
             current_app.logger.info(
-                f"Last scrape yielded less than {DEFAULT_LIMIT}, indicating no more verdicts can be found."
+                f"Collecting verdicts from {SEARCH_ENDPOINT} with params: {params}"
             )
-            break
+            r = session.get(SEARCH_ENDPOINT, params=params)
+
+            if not r.ok or r.url == FAULTY_URL:
+                current_app.logger.error(
+                    f"Error during verdict collection: STATUS_CODE {r.status_code} | URL {r.url} | CONTENT {r.content}"
+                )
+                return
+
+            verdicts = extract_verdicts(to_soup(r.content))
+
+            current_app.logger.info(f"{len(verdicts)} verdicts found for {r.url}")
+
+            for verdict in verdicts:
+                verdict_kwargs = {
+                    "ecli": verdict.id.text,
+                    "title": verdict.title.text,
+                    "summary": verdict.summary.text,
+                    "uri": verdict.link["href"],
+                }
+                if not verdict_already_exists(verdict_kwargs.get("ecli")):
+                    Verdict.create(**verdict_kwargs)
+                else:
+                    current_app.logger.debug(
+                        f'Verdict for {verdict_kwargs.get("ecli")} already exists'
+                    )
+
+            params["from"] = params["from"] + DEFAULT_LIMIT
+
+            if len(verdicts) < DEFAULT_LIMIT:
+                current_app.logger.info(
+                    f"Last scrape yielded less than {DEFAULT_LIMIT}, indicating no more verdicts can be found."
+                )
+                break

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,7 @@ pytz==2024.2
 PyYAML==6.0.2
 requests==2.32.3
 requests-mock==1.12.1
+requests-ratelimiter==0.7.0
 sentry-sdk==2.17.0
 six==1.16.0
 soupsieve==2.6


### PR DESCRIPTION
We now use the RechtspraakScrapeSession with built in rate limiting to make sure we don't 'hammer' the website of the judiciary. We limit scraping to 30 requests per minute. Note that this means that enriching the 5612 judges currently on openrechtspraak.nl will take approximately 3h10m every day.

Closes #77.