### PR TITLE
Fix migration order that prevented deployment in production

### DIFF
--- a/migrations/versions/2684f0161ed5_deduplicate_people_based_on_toon_naam.py
+++ b/migrations/versions/2684f0161ed5_deduplicate_people_based_on_toon_naam.py
@@ -38,6 +38,9 @@ def upgrade():
     for id_ in ids_to_clean:
         person = session.query(Person).filter(Person.id == id_).first()
 
+        if not person:
+            continue
+
         for pd in person.professional_detail:
             session.delete(pd)
         for sj in person.side_job:

--- a/migrations/versions/30093f73cee6_add_outside_of_judiciary_to_.py
+++ b/migrations/versions/30093f73cee6_add_outside_of_judiciary_to_.py
@@ -1,7 +1,7 @@
 """Add outside_of_judiciary  to professional detail
 
 Revision ID: 30093f73cee6
-Revises: 2684f0161ed5
+Revises: d6e38fddc8c0
 Create Date: 2026-05-02 17:22:23.963233
 
 """
@@ -9,12 +9,12 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from app.models import Person, ProfessionalDetail
+from app.models import ProfessionalDetail
 
 
 # revision identifiers, used by Alembic.
 revision = '30093f73cee6'
-down_revision = '2684f0161ed5'
+down_revision = 'd6e38fddc8c0'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/d6e38fddc8c0_add_location_to_professional_detail.py
+++ b/migrations/versions/d6e38fddc8c0_add_location_to_professional_detail.py
@@ -1,7 +1,7 @@
 """Add location to professional detail
 
 Revision ID: d6e38fddc8c0
-Revises: 30093f73cee6
+Revises: 2684f0161ed5
 Create Date: 2026-05-02 18:49:22.514275
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd6e38fddc8c0'
-down_revision = '30093f73cee6'
+down_revision = '2684f0161ed5'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
@siccovansas the bad deployment because of the `.location` attribute on `ProfessionalDetail` was caused by a migration order. Sloppy on my end; sorry!